### PR TITLE
PR of quick corrections

### DIFF
--- a/values-ja/strings.xml
+++ b/values-ja/strings.xml
@@ -187,17 +187,17 @@
     <string name="restarting_adventure">アドベンチャーリスタート中…</string>
 
     <!-- Suffixes for ORDINAL numbers !-->
-    <string name="ordinal_first">%d番目</string>
-    <string name="ordinal_second">%d番目</string>
-    <string name="ordinal_third">%d番目</string>
-    <string name="ordinal_fourth">%d番目</string>
-    <string name="ordinal_fifth">%d番目</string>
-    <string name="ordinal_sixth">%d番目</string>
-    <string name="ordinal_seventh">%d番目</string>
-    <string name="ordinal_eighth">%d番目</string>
-    <string name="ordinal_ninth">%d番目</string>
-    <string name="ordinal_zeroth">%d番目</string>
-    <string name="ordinal_fallback">%d番目</string>
+    <string name="ordinal_first">%d位</string>
+    <string name="ordinal_second">%d位</string>
+    <string name="ordinal_third">%d位</string>
+    <string name="ordinal_fourth">%d位</string>
+    <string name="ordinal_fifth">%d位</string>
+    <string name="ordinal_sixth">%d位</string>
+    <string name="ordinal_seventh">%d位</string>
+    <string name="ordinal_eighth">%d位</string>
+    <string name="ordinal_ninth">%d位</string>
+    <string name="ordinal_zeroth">%d位</string>
+    <string name="ordinal_fallback">%d位</string>
 
     <!-- In Game UI !-->
     <string name="player_size">サイズ: %d</string>
@@ -216,7 +216,7 @@
     <string name="highest_rank">最高ランク</string>
     <string name="session_stat_highest_size">最高サイズ</string>
     <string name="leaderboard">リーダーボード</string>
-    <string name="session_stats">Session Stats</string>
+    <string name="session_stats">現在ゲームの統計</string>
     <string name="debug">デバッグ</string>
     <string name="profiler">プロファイラー</string>
 
@@ -255,9 +255,9 @@
     <string name="open_menu">メニューを開く</string>
     <string name="stop_spectating">観戦者モードを終了</string>
     <string name="spectate">観戦する</string>
-    <string name="previous_entity">Previous Entity</string>
-    <string name="next_entity">Next Entity</string>
-    <string name="left">退室済み</string> <!-- left as in remaining, not the left direction -->
+    <string name="previous_entity">前のエンティティ</string>
+    <string name="next_entity">次のエンティティ</string>
+    <string name="left">残り</string> <!-- left as in remaining, not the left direction -->
     <string name="total">合計</string>
     <string name="unknown">不明</string>
     <string name="invalid_selection">無効な選択です！</string>
@@ -265,3 +265,4 @@
     <string name="room_crash">ルームがクラッシュしました: %s</string>
     <string name="copied_to_clipboard">クリップボードにコピーされました。</string>
 </resources>
+

--- a/values-ja/strings.xml
+++ b/values-ja/strings.xml
@@ -183,7 +183,7 @@
     <string name="level_up">レベルアップ！ %d</string>
     <string name="game_over">ゲームオーバー！</string>
     <string name="stage_clear">ステージ %s 完了！</string>
-    <string name="stage_failed">ステージ %s 失敗れ</string>
+    <string name="stage_failed">ステージ %s 失敗！</string>
     <string name="restarting_adventure">アドベンチャーリスタート中…</string>
 
     <!-- Suffixes for ORDINAL numbers !-->

--- a/values-ja/strings.xml
+++ b/values-ja/strings.xml
@@ -69,7 +69,7 @@
     <string name="max_split_pieces">最大スプリット数:</string>
     <string name="quick_merge">ブロブを即座にマージ</string>
     <string name="no_holes">ホールなし</string>
-    <string name="warning_no_holes">統計は保存しません</string>
+    <string name="warning_no_holes">統計は保存されません</string>
 
     <!-- Profile -->
     <string name="profile">プロフィール</string>

--- a/values-pt/strings.xml
+++ b/values-pt/strings.xml
@@ -25,7 +25,7 @@
     <string name="language_portuguese">Português</string>
     <string name="language_spanish">Español (Espanhol)</string>
     <string name="language_japanese">日本語 (Japonês)</string>
-    <string name="language_italian">Italiano</string>
+    <string name="language_italian">Italiano (Italiano)</string>
     <string name="background">Fundo</string>
     <string name="background_black">Preto</string>
     <string name="background_white">Branco</string>
@@ -257,11 +257,12 @@
     <string name="spectate">Telar</string>
     <string name="previous_entity">Entidade Anterior</string>
     <string name="next_entity">Próxima Entidade</string>
-    <string name="left">Esquerda</string> <!-- left as in remaining, not the left direction -->
+    <string name="left">Restante</string> <!-- left as in remaining, not the left direction -->
     <string name="total">Total</string>
     <string name="unknown">Desconhecido</string>
     <string name="invalid_selection">Seleção inválida!</string>
     <string name="error">Erro</string>
     <string name="room_crash">A sala travou: %s</string>
     <string name="copied_to_clipboard">Copiado para a área de transferência.</string>
+
 </resources>


### PR DESCRIPTION
I've made a few corrections to some translations.

---

"Left" may mean the following:

- **Portuguese**
  - "Esquerda" – as in _left direction_
  - "Saiu" – as in _left the room_
  - "Restante" – as in _time left_

- **Japanese**
  - 左側 – as in _left direction_
  - 退室 or 退出 – as in _left the room_
  - 残り(時間) – as in _time left_

Thankfully the comment has helped on getting the context.

---

Even though "Italian" is the same word for both Italian and Portuguese, in UI we still include it for higher clarity; it happens by default when we reach up the language switch setting in devices and all other apps.