### PR TITLE
Merg 1.0-alpha: Update all language files

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">غرفة خاصة</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">الجميع</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">قائمة اللاعبين</string>
     <string name="player_list_count">اللاعبون: %d ⋅ البوتات: %d ⋅ الاجمالي: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">طرد اللاعب من الغرفة</string>
     <string name="kick_confirm_message">هل تريد طرد %s من هذه الغرفة؟ قد يمكنه العودة الى الغرفة.</string>
     <string name="ban_confirm_title">حضر اللاعب من الغرفة</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">العب</string>

--- a/res/values-bn/strings.xml
+++ b/res/values-bn/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Árabe</string>
     <string name="language_bengali">বাংলা | Bengalí</string>
     <string name="language_chinese">简体中文 | Chino (Simplificado)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Checo</string>
     <string name="language_danish">Dansk | Danés</string>
     <string name="language_dutch">Nederlands | Neerlandés</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Coreano</string>
     <string name="language_polish">Polski | Polaco</string>
     <string name="language_portuguese">Português (Brasil) | Portugués (Brasil)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Rumano</string>
     <string name="language_russian">Русский | Ruso</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">Todo</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">LISTA DE JUGADORES</string>
     <string name="player_list_count">Jugadores: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Expulsar Jugador</string>
     <string name="kick_confirm_message">Expulsar a %s de esta sala? Podría volver a unirse.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Jugar</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-fil/strings.xml
+++ b/res/values-fil/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-id/strings.xml
+++ b/res/values-id/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Arabo</string>
     <string name="language_bengali">বাংলা | Bengalese</string>
     <string name="language_chinese">简体中文 | Cinese (Semplificato)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Ceco</string>
     <string name="language_danish">Dansk | Danese</string>
     <string name="language_dutch">Nederlands | Olandese</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Coreano</string>
     <string name="language_polish">Polski | Polacco</string>
     <string name="language_portuguese">Português (Brasil) | Portoghese (Brasile)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Rumeno</string>
     <string name="language_russian">Русский | Russo</string>
     <string name="language_spanish">Español | Spagnolo</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">Tutti</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Gioca</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية｜アラビア語</string>
     <string name="language_bengali">বাংলা｜ベンガル語</string>
     <string name="language_chinese">简体中文｜中国語（簡体）</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština｜チェコ語</string>
     <string name="language_danish">Dansk｜デンマーク語</string>
     <string name="language_dutch">Nederlands｜オランダ語</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어｜韓国語</string>
     <string name="language_polish">Polski｜ポーランド語</string>
     <string name="language_portuguese">Português (Brasil)｜ブラジルポルトガル語</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română｜ルーマニア語</string>
     <string name="language_russian">Русский｜ロシア語</string>
     <string name="language_spanish">Español｜スペイン語</string>
@@ -113,6 +115,20 @@
     <string name="play_online">オンラインプレイ</string>
     <string name="switch_server">サーバーを切り替え</string>
     <string name="x_players">%s人のプレイヤー</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s人がオンライン</string>
     <string name="x_requests">%s件の申請</string>
     <string name="private_room">プライベートルーム</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">クラン説明の保存完了！</string>
     <string name="clan_description_save">クラン説明を保存</string>
     <string name="clan_description_save_failed">クラン説明が保存できませんでした</string>
-
     <string name="clan_feature_not_unlocked">クランの機能はアンロックされていません</string>
     <string name="clan_history_event_purchase_name_color">クラン名のカラーを購入済み</string>
     <string name="clan_history_event_purchase_name_gradient">クラン名のグラデーションを購入済み</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">クラン背景の3色のグラデーションを購入済み</string>
     <string name="clan_history_event_purchase_description_color">クラン説明のカラーを購入済み</string>
     <string name="clan_history_event_rename">クラン名を変更済み</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">すべて</string>
@@ -702,6 +729,7 @@
     <string name="players">プレイヤー</string>
     <string name="player_list_title">プレイヤーのリスト</string>
     <string name="player_list_count">プレイヤー数: %d・ボット数: %d・総数: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">プレイヤーをキック</string>
     <string name="kick_confirm_message">「%s」さんをキックしますか？まだ再参加できます。</string>
     <string name="ban_confirm_title">プレイヤーをバン</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">カスタム画像のアップロード</string>
     <string name="custom_image_refund">カスタム画像の返金</string>
     <string name="custom_image_slot">画像 %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">アイコンを報告</string>
     <string name="report_avatar_message">「%1$s」さんのアイコンを報告しますか？</string>
     <string name="report_avatar_success">アイコンの報告完了</string>
     <string name="report_avatar_failed">アイコンが報告できませんでした</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">プレイ</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | 아랍어</string>
     <string name="language_bengali">বাংলা | 벵골어</string>
     <string name="language_chinese">简体中文 | 중국어 (간체)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | 체코어</string>
     <string name="language_danish">Dansk | 덴마크</string>
     <string name="language_dutch">Nederlands | 네덜란드어</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski | 폴란드어</string>
     <string name="language_portuguese">Português (Brasil) | 포르투갈어 (브라질)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | 루마니아어</string>
     <string name="language_russian">Русский | 러시아어</string>
     <string name="language_spanish">Español | 스페인어</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Árabe</string>
     <string name="language_bengali">বাংলা | Bengali</string>
     <string name="language_chinese">简体中文 | Chinês (Simplificado)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Checo</string>
     <string name="language_danish">Dansk | Dinamarquês</string>
     <string name="language_dutch">Nederlands | Neerlandês</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Coreano</string>
     <string name="language_polish">Polski | Polonês</string>
     <string name="language_portuguese">Português (Brasil)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Romeno</string>
     <string name="language_russian">Русский | Russo</string>
     <string name="language_spanish">Español | Espanhol</string>
@@ -113,6 +115,20 @@
     <string name="play_online">JOGAR ONLINE</string>
     <string name="switch_server">Alterar Servidor</string>
     <string name="x_players">%s jogadores</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s pedido(s)</string>
     <string name="private_room">Sala Privada</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Descrição do clã salva</string>
     <string name="clan_description_save">Salvar Descrição do Clã</string>
     <string name="clan_description_save_failed">Falha ao salvar a descrição do clã</string>
-
     <string name="clan_feature_not_unlocked">Recurso não desbloqueado</string>
     <string name="clan_history_event_purchase_name_color">Comprou Cores para o Nome do Clã</string>
     <string name="clan_history_event_purchase_name_gradient">Comprou Gradiente para o Nome do Clã</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Comrpou Gradiente 2 para o Fundo do Clã</string>
     <string name="clan_history_event_purchase_description_color">Comprou Cores para a Descrição do Clã</string>
     <string name="clan_history_event_rename">Renomeou Clã</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">Tudo</string>
@@ -702,6 +729,7 @@
     <string name="players">Jogadores</string>
     <string name="player_list_title">LISTA DE JOGADORES</string>
     <string name="player_list_count">Jogadores: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Expulsar Jogador(a)</string>
     <string name="kick_confirm_message">Expulsar este(a) jogador(a) da sala: %s? Ele(a) ainda poderá entrar na sala.</string>
     <string name="ban_confirm_title">Banir Jogador(a)</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Envio de Imagem Personalizada</string>
     <string name="custom_image_refund">Reembolso de Imagem personalizada</string>
     <string name="custom_image_slot">Imagem %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Denunciar Ícone do Perfil</string>
     <string name="report_avatar_message">Denunciar o ícone do perfil de %1$s?</string>
     <string name="report_avatar_success">Ícone denunciado</string>
     <string name="report_avatar_failed">Falha na denúncia do ícone</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Jogar</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Árabe</string>
     <string name="language_bengali">বাংলা | Bengali</string>
     <string name="language_chinese">简体中文 | Chinês (Simplificado)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Checo</string>
     <string name="language_danish">Dansk | Dinamarquês</string>
     <string name="language_dutch">Nederlands | Neerlandês</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Coreano</string>
     <string name="language_polish">Polski | Polonês</string>
     <string name="language_portuguese">Português (Brasil)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Romeno</string>
     <string name="language_russian">Русский | Russo</string>
     <string name="language_spanish">Español | Espanhol</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي (Arabă)</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português (Portugheză)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español (Spaniolă)</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Arapça</string>
     <string name="language_bengali">বাংলা | Bengalce</string>
     <string name="language_chinese">简体中文 | Çince (Basitleştirilmiş)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Çekçe</string>
     <string name="language_danish">Dansk | Danca</string>
     <string name="language_dutch">Nederlands | Hollandaca</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Korece</string>
     <string name="language_polish">Polski | Lehçe</string>
     <string name="language_portuguese">Português (Brasil) | Portekizce (Brezilya)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Romence</string>
     <string name="language_russian">Русский | Rusça</string>
     <string name="language_spanish">Español | İspanyolca</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">عربي</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어</string>
     <string name="language_polish">Polski</string>
     <string name="language_portuguese">Português</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română</string>
     <string name="language_russian">Русский</string>
     <string name="language_spanish">Español</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية｜阿拉伯语</string>
     <string name="language_bengali">বাংলা｜孟加拉语</string>
     <string name="language_chinese">简体中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština｜捷克语</string>
     <string name="language_danish">Dansk｜丹麦语</string>
     <string name="language_dutch">Nederlands｜荷兰语</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어｜韩语</string>
     <string name="language_polish">Polski｜波兰语</string>
     <string name="language_portuguese">Português (Brasil)｜葡萄牙语（巴西）</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română｜罗马尼亚语</string>
     <string name="language_russian">Русский｜俄语</string>
     <string name="language_spanish">Español｜西班牙语</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية｜阿拉伯文</string>
     <string name="language_bengali">বাংলা｜孟加拉文</string>
     <string name="language_chinese">简体中文｜簡體中文</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština｜捷克文</string>
     <string name="language_danish">Dansk｜丹麥文</string>
     <string name="language_dutch">Nederlands｜荷蘭文</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어｜韓文</string>
     <string name="language_polish">Polski｜波蘭文</string>
     <string name="language_portuguese">Português (Brasil)｜葡萄牙文（巴西）</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română｜羅馬尼亞文</string>
     <string name="language_russian">Русский｜俄文</string>
     <string name="language_spanish">Español｜西班牙文</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="language_arabic">العربية | Arabic</string>
     <string name="language_bengali">বাংলা | Bengali</string>
     <string name="language_chinese">简体中文 | Chinese (Simplified)</string>
+    <string name="language_chinese_traditional">繁體中文 | Chinese (Traditional)</string>
     <string name="language_czech">Čeština | Czech</string>
     <string name="language_danish">Dansk | Danish</string>
     <string name="language_dutch">Nederlands | Dutch</string>
@@ -38,6 +39,7 @@
     <string name="language_korean">한국어 | Korean</string>
     <string name="language_polish">Polski | Polish</string>
     <string name="language_portuguese">Português (Brasil) | Portuguese (Brazil)</string>
+    <string name="language_portuguese_portugal">Português (Portugal) | Portuguese (Portugal)</string>
     <string name="language_romanian">Română | Romanian</string>
     <string name="language_russian">Русский | Russian</string>
     <string name="language_spanish">Español | Spanish</string>
@@ -113,6 +115,20 @@
     <string name="play_online">PLAY ONLINE</string>
     <string name="switch_server">Switch Server</string>
     <string name="x_players">%s players</string>
+    <string name="x_player">%s player</string>
+    <string name="unrated">Unrated</string>
+    <string name="rating">Rating</string>
+    <string name="find_opponent">FIND OPPONENT</string>
+    <string name="leave_matchmaking">LEAVE MATCHMAKING</string>
+    <string name="searching">Searching…</string>
+    <string name="x_searching_y_playing">%s searching · %s playing</string>
+    <string name="global_position">Global #%s</string>
+    <string name="wins_draws_losses_winrate">Wins: %s · Draws: %s · Losses: %s · Win rate: %s%%</string>
+    <string name="match_starts_in">Match starts in…</string>
+    <string name="victory">VICTORY</string>
+    <string name="defeat">DEFEAT</string>
+    <string name="draw">DRAW</string>
+    <string name="competitive_menu">COMPETITIVE</string>
     <string name="x_online">%s online</string>
     <string name="x_requests">%s request(s)</string>
     <string name="private_room">Private Room</string>
@@ -424,7 +440,6 @@
     <string name="clan_description_saved">Clan description saved</string>
     <string name="clan_description_save">Save Clan Description</string>
     <string name="clan_description_save_failed">Failed to save clan description</string>
-
     <string name="clan_feature_not_unlocked">Feature not unlocked</string>
     <string name="clan_history_event_purchase_name_color">Purchased Clan Name Colors</string>
     <string name="clan_history_event_purchase_name_gradient">Purchased Clan Name Gradient</string>
@@ -434,6 +449,18 @@
     <string name="clan_history_event_purchase_triple_gradient">Purchased Clan Triple Gradient</string>
     <string name="clan_history_event_purchase_description_color">Purchased Clan Description Color</string>
     <string name="clan_history_event_rename">Renamed Clan</string>
+
+    <!-- Leaderboard !-->
+    <string name="leaderboard_type">Leaderboard Type</string>
+    <string name="leaderboard_xp_description">Experience points. Required to level up. Can be obtained by doing any meaningful action in game.</string>
+    <string name="leaderboard_period_daily">Daily</string>
+    <string name="leaderboard_period_weekly">Weekly</string>
+    <string name="leaderboard_period_monthly">Monthly</string>
+    <string name="leaderboard_period_all_time">All Time</string>
+    <string name="leaderboard_score">Score</string>
+    <string name="leaderboard_rank">Rank</string>
+    <string name="leaderboard_empty">No entries yet</string>
+    <string name="leaderboard_load_error">Failed to load leaderboard</string>
 
     <!-- Statistics !-->
     <string name="all">All</string>
@@ -702,6 +729,7 @@
     <string name="players">Players</string>
     <string name="player_list_title">PLAYER LIST</string>
     <string name="player_list_count">Players: %d ⋅ Bots: %d ⋅ Total: %d</string>
+    <string name="player_list_count_with_spectators">Players: %d ⋅ Bots: %d ⋅ Spectators: %d ⋅ Total: %d</string>
     <string name="kick_confirm_title">Kick Player</string>
     <string name="kick_confirm_message">Kick %s from this room? They may rejoin.</string>
     <string name="ban_confirm_title">Ban Player</string>
@@ -731,10 +759,43 @@
     <string name="custom_image_bought">Custom Image Upload</string>
     <string name="custom_image_refund">Custom Image Refund</string>
     <string name="custom_image_slot">Image %1$d</string>
+
+    <!-- Custom image skin -->
+    <string name="custom_image_skin_load_failed">Failed to load your custom skin: %1$s</string>
+    <string name="custom_image_no_approved_image">No approved image in slot %1$d</string>
     <string name="report_avatar">Report Avatar</string>
     <string name="report_avatar_message">Report the avatar of %1$s?</string>
     <string name="report_avatar_success">Avatar reported</string>
     <string name="report_avatar_failed">Failed to report avatar</string>
+
+    <!-- Account recovery -->
+    <string name="account_recovery">Account Recovery</string>
+    <string name="recovery_info">Same Wi-Fi and device are required, otherwise recovery may fail.</string>
+    <string name="recovery_continue">Continue</string>
+    <string name="recovery_enter_account_id">Enter your account ID</string>
+    <string name="recovery_account_id_placeholder">Account ID</string>
+    <string name="recovery_load_preview">Load account</string>
+    <string name="recovery_new_email_label">New email address</string>
+    <string name="recovery_new_email_placeholder">new@example.com</string>
+    <string name="recovery_change_mail">Change mail</string>
+    <string name="recovery_confirm_title">Change account email?</string>
+    <string name="recovery_confirm_body">You are about to change the email on this account to %1$s. You will sign in with the matching Google account next. This cannot be undone.</string>
+    <string name="recovery_success_body">The account email has been changed to %1$s. Please sign in now with your new Google account.</string>
+    <string name="recovery_error_invalid_id">Please enter a valid account ID.</string>
+    <string name="recovery_error_invalid_email">Please enter a valid email address.</string>
+    <string name="recovery_error_invalid_request">Invalid request. Please try again.</string>
+    <string name="recovery_error_network">Network error. Please check your connection and try again.</string>
+    <string name="recovery_error_fingerprint_mismatch">This device and network do not match this account. Recovery requires the same phone on a Wi-Fi you have used with that account before.</string>
+    <string name="recovery_error_email_taken">This email is already used by another account. Delete that account or use a different email.</string>
+    <string name="recovery_error_google_taken">This Google account is already linked to another account.</string>
+    <string name="recovery_error_email_mismatch">The email you typed does not match the Google account you signed in with.</string>
+    <string name="recovery_error_cooldown">This account was recently recovered. Please wait 24 hours before trying again.</string>
+    <string name="recovery_error_banned">This account is banned and cannot be recovered.</string>
+    <string name="recovery_error_not_found">No account found with that ID.</string>
+    <string name="recovery_error_rate_limited">Too many attempts. Please wait and try again later.</string>
+    <string name="recovery_error_google_invalid">Could not verify your Google account. Please try again.</string>
+    <string name="recovery_error_google_cancelled">Google sign-in was cancelled or failed.</string>
+    <string name="recovery_error_internal">Something went wrong on our side. Please try again later.</string>
 
     <!-- Miscellaneous !-->
     <string name="play">Play</string>


### PR DESCRIPTION
## Summary

- Updated English source of truth with **56 new strings** covering:
  - **Competitive 1v1 / matchmaking**: rating, matchmaking flow, win/loss/draw outcomes
  - **Leaderboards**: period switching (Daily/Weekly/Monthly/All Time), XP description, empty/error states
  - **Account recovery flow**: full set of strings for the new email-recovery feature (entry, confirmation, ~15 error cases)
  - **Spectator-aware player list** and **custom-image skin error** messages
  - **Language picker**: new entries for `language_portuguese_portugal` and `language_chinese_traditional`
- Synced **all 27 language files** to match English structure and line count (915 lines each).
- Missing strings were inserted **in English** — translators only need to fill in the new entries.
- **No existing English strings were modified**, so all prior translations remain valid.

## Notes for translators

If you maintain a language, you only need to translate the new English entries that appear in your `values-<lang>/strings.xml`. The structure, ordering, and existing translations have been preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)