### PR TITLE
Restore translator values lost in PR #124

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -149,7 +149,7 @@
     <string name="remove_friend_message">هل انت متاكد من رغبتك في ازالة "%1$s" (المعرف: %2$d) كصديق؟</string>
     <string name="cancel_request_title">الغاء الطلب</string>
     <string name="cancel_request_message">هل انت متاكد من رغبتك في الغاء طلب الصداقة إلى "%1$s" (المعرف: %2$d)؟</string>
-    <string name="friend_request_error_self">Can't send friend request to yourself</string>
+    <string name="friend_request_error_self">لا يمكنك إرسال طلب صداقة الى نفسك</string>
     <string name="friend_request_error_already_sent">تم ارسال طلب الصداقة بالفعل</string>
     <string name="friend_request_error_already_friends">اصدقاء بالفعل</string>
     <string name="friend_request_error_list_full">قائمة الاصدقاء ممتلئة</string>
@@ -243,7 +243,7 @@
     <string name="ad_not_loaded">لم يتم تحميل الإعلان بعد</string>
     <string name="ad_show_failed">فشل عرض الإعلان</string>
     <string name="ad_load_failed">فشل تحميل الإعلان</string>
-    <string name="ad_rate_limited">You've watched too many ads recently. Please try again in %s.</string>
+    <string name="ad_rate_limited">لقد شاهدت الكثير من الإعلانات مؤخرا. يرجى المحاولة مرة اخرى خلال %s.</string>
     <string name="time_hrs">ساعة</string>
     <string name="time_min">دقيقة</string>
     <string name="time_sec">ثانية</string>
@@ -779,7 +779,7 @@
     <string name="block_player">حضر اللاعب</string>
     <string name="unblock_player">إلغاء حضر اللاعب</string>
     <string name="block_confirm_title">حضر اللاعب؟</string>
-    <string name="block_confirm_message">Are you sure you want to block %s? You will both be unable to send each other mails or friend requests, and will be removed from each other's friends list.</string>
+    <string name="block_confirm_message">هل أنت متأكد من رغبتك في حظر %s؟ لن تتمكن أنت وهو من إرسال رسائل بريد إلكتروني أو طلبات صداقة إلى بعضكما البعض، وسيتم حذفكما من قائمة أصدقاء بعضكما البعض.</string>
     <string name="player_unblocked">تم إلغاء حظر اللاعب</string>
     <string name="player_blocked">تم حضر اللاعب</string>
     <string name="you_blocked_user">انت حضرت هذا اللاعب</string>
@@ -795,7 +795,7 @@
     <string name="enter_ip">ادخل IP</string>
     <string name="join_ip_title">ادخل IP ادريس</string>
     <string name="tap_to_reveal">انقر للكشف</string>
-    <string name="remote_lan_connections">To allow other clients to join remotely through public IP, you must port forward UDP %d or enable DMZ for your device on your router's settings. Please note that connections may still fail if your network is under Symmetric NAT/CGNAT. For more information and to check your current NAT type, visit %s.</string>
+    <string name="remote_lan_connections">للسماح للعملاء الاخرين بالانضمام عن بعد عبر عنوان IP عام، يجب عليك إعادة توجيه منفذ UDP %d او تفعيل منطقة DMZ لجهازك في إعدادات جهاز التوجيه. يُرجى العلم بان الاتصالات قد تفشل إذا كانت شبكتك تستخدم ترجمة عناوين الشبكة المتماثلة/CGNAT. لمزيد من المعلومات وللتحقق من نوع NAT الحالي، تفضل بزيارة %s.</string>
 
     <!-- Player List -->
     <string name="players">Players</string>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -149,7 +149,7 @@
     <string name="remove_friend_message">¿Seguro(a) qué quieres dejar de ser Amigo de \"%1$s\" (ID: %2$d)?</string>
     <string name="cancel_request_title">Cancelar Solicitud</string>
     <string name="cancel_request_message">¿Seguro(a) que quieres eliminar la Solicitud de Amistad de \"%1$s\" (ID: %2$d)?</string>
-    <string name="friend_request_error_self">Can't send friend request to yourself</string>
+    <string name="friend_request_error_self">Ups, no puedes enviarte una Solicitud de Amistad a ti mismo.</string>
     <string name="friend_request_error_already_sent">Ya has enviado una Solicitud de Amistad</string>
     <string name="friend_request_error_already_friends">Ya son Amigos</string>
     <string name="friend_request_error_list_full">Lista de Amigos Llena</string>
@@ -157,35 +157,35 @@
     <!-- Competitive (ranked 1v1) -->
     <string name="competitive">Competitivo</string>
     <string name="competitive_menu">Menú Competitivo</string>
-    <string name="competitive_history">Competitive History</string>
-    <string name="rating_label">Rating</string>
+    <string name="competitive_history">Historial Competitivo</string>
+    <string name="rating_label">Clasificación</string>
     <string name="unrated">Sin Clasificar</string>
     <string name="find_opponent">ENCONTRAR OPONENTE</string>
     <string name="leave_matchmaking">ABANDONAR EMPAREJAMIENTO</string>
-    <string name="searching_ellipsis">Searching…</string>
-    <string name="x_searching_y_playing">%1$s searching · %2$s playing</string>
+    <string name="searching_ellipsis">Buscando…</string>
+    <string name="x_searching_y_playing">%1$s buscando · %2$s jugando</string>
     <string name="x_searching">%d searching</string>
     <string name="x_playing">%d playing</string>
     <string name="global_position">Global #%s</string>
     <string name="global_label">Global #</string>
-    <string name="wins_draws_losses_winrate">Wins: %1$s · Draws: %2$s · Losses: %3$s · Win rate: %4$s%%</string>
-    <string name="stat_wins_label">Wins: </string>
-    <string name="stat_draws_label"> · Draws: </string>
-    <string name="stat_losses_label"> · Losses: </string>
-    <string name="stat_winrate_label"> · Win rate: </string>
+    <string name="wins_draws_losses_winrate">Victorias: %1$s · Empates: %2$s · Derrotas: %3$s · Tasa de Victorias: %4$s%%</string>
+    <string name="stat_wins_label">Victorias: </string>
+    <string name="stat_draws_label"> · Empates: </string>
+    <string name="stat_losses_label"> · Derrotas: </string>
+    <string name="stat_winrate_label"> · Tasa de Victorias: </string>
     <string name="match_starts_in">La batalla empieza en…</string>
     <string name="vs_label">VS</string>
-    <string name="ongoing_matches">Ongoing matches</string>
-    <string name="match_status_starting">STARTING</string>
-    <string name="match_status_in_progress">IN PROGRESS</string>
-    <string name="match_status_finished">FINISHED</string>
+    <string name="ongoing_matches">Batallas en curso</string>
+    <string name="match_status_starting">EMPEZANDO BATALLA</string>
+    <string name="match_status_in_progress">BATALLA EMPEZADA</string>
+    <string name="match_status_finished">BATALLA TERMINADA</string>
     <string name="victory">VICTORIA</string>
     <string name="defeat">DERROTA</string>
     <string name="draw">EMPATE</string>
-    <string name="play_again">Play Again</string>
-    <string name="play_x_more_matches_to_rated">Play %d more matches to be rated!</string>
-    <string name="play_one_more_match_to_rated">Play 1 more match to be rated!</string>
-    <string name="history_viewer_vs_opponent">%1$s vs %2$s</string>
+    <string name="play_again">Jugar de Nuevo</string>
+    <string name="play_x_more_matches_to_rated">¡Juega %d partidas más para Clasificar!</string>
+    <string name="play_one_more_match_to_rated">¡Juega un partido más para obtener Puntuación!</string>
+    <string name="history_viewer_vs_opponent">%1$svs%2$s</string>
     <string name="prizes">Prizes</string>
     <string name="prizes_dialog_intro">Before every season reset, top players will receive a Voidstone reward based on their performance!</string>
     <string name="current_season">Current Season</string>
@@ -243,7 +243,7 @@
     <string name="ad_not_loaded">El Anuncio aún no ha cargado</string>
     <string name="ad_show_failed">Error al mostrar Anuncio</string>
     <string name="ad_load_failed">Error al cargar Anuncio</string>
-    <string name="ad_rate_limited">You've watched too many ads recently. Please try again in %s.</string>
+    <string name="ad_rate_limited">Has visto demasiados Anuncios recientemente. Inténtalo de nuevo en %s.</string>
     <string name="time_hrs">hr(s)</string>
     <string name="time_min">min(s)</string>
     <string name="time_sec">seg(s)</string>
@@ -274,13 +274,13 @@
     <string name="not_logged_in">¡No has Iniciado Sesión!</string>
     <string name="login">Iniciar Sesión</string>
     <string name="login_google">Iniciar Sesión con Google</string>
-    <string name="login_apple">Sign in with Apple</string>
+    <string name="login_apple">Iniciar Sesión con Apple</string>
     <string name="logout">Cerrar Sesión</string>
     <string name="logout_all_devices">Cerrar Sesión en todos los dispositivos</string>
     <string name="change_name">Cambiar Nombre</string>
     <string name="copy_id">Copiar ID</string>
-    <string name="share_id">Share ID</string>
-    <string name="share_id_message">Add me on Merg! My ID is %1$s</string>
+    <string name="share_id">Compartir ID</string>
+    <string name="share_id_message">¡Agrégame en Merg! Mi ID es %1$s</string>
     <string name="created">Creada %s</string>
     <string name="last_seen">Última Conexión %s</string>
     <string name="save_profile_description">Guardar Descripción del Perfil</string>
@@ -451,9 +451,9 @@
     <string name="clan_full">El Clan está Lleno.</string>
     <string name="clan_join_button_full">Clan Lleno</string>
     <string name="clan_join_request_sent">Solicitud de Ingreso Enviada</string>
-    <string name="clan_invite_list_full">This clan's invite list is full (max 100).</string>
+    <string name="clan_invite_list_full">La Lista de Invitaciones está Llena (100/100).</string>
     <string name="clan_player_invite_list_full">Ups, este Jugador ya tiene el número máximo de Invitaciones de Clan pendientes.</string>
-    <string name="clan_request_list_full">This clan's join request list is full (max 100).</string>
+    <string name="clan_request_list_full">La Lista de Solicitudes de Ingreso está Llena (100/100).</string>
     <string name="clan_donate_voidstones">Donar Voidstones</string>
     <string name="clan_donate_hint">100 – 100,000</string>
     <string name="clan_donate_sent">¡Donación Enviada!</string>
@@ -478,7 +478,7 @@
     <string name="clan_search_hint">Buscar por ID o por Nombre</string>
     <string name="clan_promote_to_owner">Ascender a Líder</string>
     <string name="clan_transfer_ownership_title">Transfeir Propiedad</string>
-    <string name="clan_transfer_ownership_message">You are about to promote \"%1$s\" (ID: %2$d) to Owner. You will be demoted to Co-Owner. This cannot be undone.\n\nType the player's ID to confirm:</string>
+    <string name="clan_transfer_ownership_message">¿Seguro(a) que quieres Ascender a \"%1$s\" (ID: %2$d) como Líder. Serás Degradado a Colíder. Esta acción es irreversible.\n\nType el jugador\'s ID confirmar:</string>
     <string name="clan_transfer_ownership_id_mismatch">La ID no coincide</string>
     <string name="clan_customize_name_color">Color de Nombre del Clan</string>
     <string name="clan_customize_tag_color">Color de Siglas del Clan</string>
@@ -513,8 +513,8 @@
     <!-- Leaderboard !-->
     <string name="leaderboard_type">Tipo de Tabla</string>
     <string name="leaderboard_xp_description">Puntos de Experiencia. Necesarios para subir de nivel. Se pueden obtener realizando cualquier acción significativa en el Juego.</string>
-    <string name="leaderboard_competitive_description">Ranked 1v1 ladder. Only players who have completed at least 12 competitive matches are listed.</string>
-    <string name="leaderboard_rating">Rating</string>
+    <string name="leaderboard_competitive_description">Clasificación 1vs1. Solo se muestran los Jugadores que hayan completado al menos 12 Partidas Competitivas.</string>
+    <string name="leaderboard_rating">Clasificación</string>
     <string name="leaderboard_period_daily">Diario</string>
     <string name="leaderboard_period_weekly">Semanal</string>
     <string name="leaderboard_period_monthly">Mensual</string>
@@ -588,7 +588,7 @@
     <string name="gamemode_adventure">Aventura</string>
     <string name="gamemode_soccer">Fútbol</string>
     <string name="gamemode_coming_soon">Muy Pronto…</string>
-    <string name="gamemode_competitive">Competitive</string>
+    <string name="gamemode_competitive">Competitivo</string>
     <string name="gamemode_multimerg">MultiMerg</string>
     <string name="description_classic">¡Cómete a Jugadores más pequeños y conviértete en el blob más Grande del universo! Usa tu tamaño para dominar en el mapa, ¡pero ten cuidado, los Jugadores más Grandes te quieren comer!</string>
     <string name="description_teams">¡Une fuerzas con otros Jugadores del mismo Color! Trabajen juntos para comerse a los enemigos y convertirse en el Equipo que domine la Clasificación. Los compañeros de Equipo no pueden comerse entre sí.</string>
@@ -598,7 +598,7 @@
     <string name="description_adventure">¡Completa etapas desafiantes con objetivos únicos! Avanza por niveles de dificultad creciente, gana recompensas y descubre hasta dónde puedes llegar. ¡Cada etapa trae nuevos desafíos!</string>
     <string name="description_soccer">Captura el balón y anótalo a la portería contraria para anotar Gol. ¡El Equipo con más Goles al finalizar el Tiempo gana!</string>
     <string name="description_coming_soon">¡Este Modo estará Disponible Próximamente, no te lo pierdas!</string>
-    <string name="description_competitive">Ranked 1v1 survival! Earn rating by beating opponents of similar skill. A 3-minute match with a 2-minute overtime if neither player dies. Win to climb the global leaderboard, lose and drop down, but the rating swing depends on the gap between you and your opponent.</string>
+    <string name="description_competitive">¡Supervivencia Clasificatoria 1vs1! Gana Puntos de Clasificación al vencer a oponentes de habilidad similar. Partida de 3 minutos con 2 minutos de prórroga si ninguno de los Jugadores muere. Si ganas, subirás en la Clasificación Mundial; si pierdes, bajarás. La diferencia en la Clasificación depende de la diferencia de Nivel entre tú y tu oponente.</string>
     <string name="description_multimerg">You spawn TWO blobs and switch control between them with the yin-yang button! Only the active blob responds to your joystick, split, and shoot. The other one keeps moving in its last direction. Your two blobs can eat each other if split, but the final piece is protected.</string>
 
     <!-- Map sizes !-->
@@ -761,7 +761,7 @@
     <string name="dialog_notice">Noticia</string>
     <string name="dialog_warning">Advertencia</string>
     <string name="dialog_alert">Alerta</string>
-    <string name="dialog_dont_show_again">Don't show again</string>
+    <string name="dialog_dont_show_again">No Volver a Mostrar</string>
     <string name="dialog_dismiss">Minimizar</string>
     <string name="dialog_previous">Volver</string>
     <string name="dialog_next">Siguiente</string>
@@ -779,7 +779,7 @@
     <string name="block_player">Bloquear Jugador</string>
     <string name="unblock_player">Desbloquear Jugador</string>
     <string name="block_confirm_title">Bloquear Jugador</string>
-    <string name="block_confirm_message">Are you sure you want to block %s? You will both be unable to send each other mails or friend requests, and will be removed from each other's friends list.</string>
+    <string name="block_confirm_message">¿Seguro(a) que quieres Bloquear a %s? No podrán enviarse Correos, Solicitudes de Amistad y ambos serán Eliminados de sus Listas de Amigos.</string>
     <string name="player_unblocked">Jugador desbloqueado</string>
     <string name="player_blocked">Jugador Bloqueado</string>
     <string name="you_blocked_user">Has Bloqueado a este Jugador</string>
@@ -795,12 +795,12 @@
     <string name="enter_ip">Insertar IP</string>
     <string name="join_ip_title">Unirse a esta Dirección IP</string>
     <string name="tap_to_reveal">Toca para Revelar</string>
-    <string name="remote_lan_connections">To allow other clients to join remotely through public IP, you must port forward UDP %d or enable DMZ for your device on your router's settings. Please note that connections may still fail if your network is under Symmetric NAT/CGNAT. For more information and to check your current NAT type, visit %s.</string>
+    <string name="remote_lan_connections">Para permitir que otros Clientes se Conecten Remotamente a través de una IP Pública, debe redirigir el puerto UDP %d o habilitar la DMZ para su Dispositivo en la Configuración de su enrutador. Tenga en cuenta que las Conexiones podrían fallar si su Red utiliza NAT simétrica/CGNAT. Para obtener más información y comprobar su tipo de NAT actual, visite %s.</string>
 
     <!-- Player List -->
     <string name="players">Jugadores</string>
-    <string name="spectators">Spectators</string>
-    <string name="joined_room">Joined room %s</string>
+    <string name="spectators">Espectadores</string>
+    <string name="joined_room">Te uniste a la Sala %s</string>
     <string name="player_list_title">LISTA DE JUGADORES</string>
     <string name="staff_list_title">STAFF LIST</string>
     <string name="player_list_count">Jugadores: %d ⋅ Bots: %d ⋅ Total: %d</string>
@@ -947,7 +947,7 @@
     <string name="previous_entity">Entidad Anterior</string>
     <string name="next_entity">Siguiente Entidad</string>
     <string name="level_abbreviated">Nivel.%d</string>
-    <string name="left">Left</string> <!-- left as in remaining, not the left direction -->
+    <string name="left">Restante</string> <!-- left as in remaining, not the left direction -->
     <string name="total">Total</string>
     <string name="unknown">Desconocido</string>
     <string name="invalid_selection">Ups, la Selección no es Válida.</string>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -149,7 +149,7 @@
     <string name="remove_friend_message">「%1$s」さん（ID %2$d）をフレンドから解除してもよろしいですか？</string>
     <string name="cancel_request_title">申請をキャンセル</string>
     <string name="cancel_request_message">「%1$s」さん（ID %2$d）とのフレンド申請をキャンセルしてもよろしいですか？</string>
-    <string name="friend_request_error_self">Can't send friend request to yourself</string>
+    <string name="friend_request_error_self">フレンド申請を自分自身に送信できません。</string>
     <string name="friend_request_error_already_sent">この申請は保留中です。</string>
     <string name="friend_request_error_already_friends">すでにフレンドリストにいます。</string>
     <string name="friend_request_error_list_full">フレンドリストが満員です。</string>
@@ -157,35 +157,35 @@
     <!-- Competitive (ranked 1v1) -->
     <string name="competitive">バトルゲーム</string>
     <string name="competitive_menu">ランクバトル</string>
-    <string name="competitive_history">Competitive History</string>
-    <string name="rating_label">Rating</string>
+    <string name="competitive_history">ランクバトルの履歴</string>
+    <string name="rating_label">ランキング</string>
     <string name="unrated">ランクなし</string>
     <string name="find_opponent">対戦相手を探す</string>
     <string name="leave_matchmaking">マッチメイキングを終了</string>
-    <string name="searching_ellipsis">Searching…</string>
-    <string name="x_searching_y_playing">%1$s searching · %2$s playing</string>
+    <string name="searching_ellipsis">探しています…</string>
+    <string name="x_searching_y_playing">%1$s試合が探し中 · %2$s試合が進行中</string>
     <string name="x_searching">%d searching</string>
     <string name="x_playing">%d playing</string>
     <string name="global_position">グローバルランキング: #%s</string>
-    <string name="global_label">Global #</string>
-    <string name="wins_draws_losses_winrate">Wins: %1$s · Draws: %2$s · Losses: %3$s · Win rate: %4$s%%</string>
-    <string name="stat_wins_label">Wins: </string>
-    <string name="stat_draws_label"> · Draws: </string>
-    <string name="stat_losses_label"> · Losses: </string>
-    <string name="stat_winrate_label"> · Win rate: </string>
+    <string name="global_label">グローバルランキング: #</string>
+    <string name="wins_draws_losses_winrate">勝利回数: %1$s · 引分回数: %2$s · 敗戦回数: %3$s · 勝率: %4$s%%</string>
+    <string name="stat_wins_label">勝利回数: </string>
+    <string name="stat_draws_label"> · 引分回数: </string>
+    <string name="stat_losses_label"> · 敗戦回数: </string>
+    <string name="stat_winrate_label"> · 勝率: </string>
     <string name="match_starts_in">マッチの開始…</string>
-    <string name="vs_label">VS</string>
-    <string name="ongoing_matches">Ongoing matches</string>
-    <string name="match_status_starting">STARTING</string>
-    <string name="match_status_in_progress">IN PROGRESS</string>
-    <string name="match_status_finished">FINISHED</string>
+    <string name="vs_label">対</string>
+    <string name="ongoing_matches">進行中のマッチ</string>
+    <string name="match_status_starting">開始中</string>
+    <string name="match_status_in_progress">進行中</string>
+    <string name="match_status_finished">終了</string>
     <string name="victory">勝利</string>
     <string name="defeat">敗戦</string>
     <string name="draw">引分</string>
-    <string name="play_again">Play Again</string>
-    <string name="play_x_more_matches_to_rated">Play %d more matches to be rated!</string>
-    <string name="play_one_more_match_to_rated">Play 1 more match to be rated!</string>
-    <string name="history_viewer_vs_opponent">%1$s vs %2$s</string>
+    <string name="play_again">再プレイ</string>
+    <string name="play_x_more_matches_to_rated">あと%d試合プレイしてランキングに入りましょう！</string>
+    <string name="play_one_more_match_to_rated">あと1試合プレイしてランキングに入りましょう！</string>
+    <string name="history_viewer_vs_opponent">「%1$s」さん 対 「%2$s」さん</string>
     <string name="prizes">Prizes</string>
     <string name="prizes_dialog_intro">Before every season reset, top players will receive a Voidstone reward based on their performance!</string>
     <string name="current_season">Current Season</string>
@@ -243,7 +243,7 @@
     <string name="ad_not_loaded">広告はまだ読み込まれていません</string>
     <string name="ad_show_failed">広告が表示できませんでした</string>
     <string name="ad_load_failed">広告が読み込めませんでした</string>
-    <string name="ad_rate_limited">You've watched too many ads recently. Please try again in %s.</string>
+    <string name="ad_rate_limited">多くの広告を一度に視聴しました。%s後に再度お試しください。</string>
     <string name="time_hrs">時間</string>
     <string name="time_min">分</string>
     <string name="time_sec">秒</string>
@@ -274,13 +274,13 @@
     <string name="not_logged_in">ログインしていません！</string>
     <string name="login">ログイン</string>
     <string name="login_google">Google でサインイン</string>
-    <string name="login_apple">Sign in with Apple</string>
+    <string name="login_apple">Apple でサインイン</string>
     <string name="logout">ログアウト</string>
     <string name="logout_all_devices">すべてのデバイスでログアウト</string>
     <string name="change_name">名前変更</string>
     <string name="copy_id">IDをコピー</string>
-    <string name="share_id">Share ID</string>
-    <string name="share_id_message">Add me on Merg! My ID is %1$s</string>
+    <string name="share_id">IDをシェア</string>
+    <string name="share_id_message">Mergで追加してね！ID %1$s</string>
     <string name="created">作成日付: %s</string>
     <string name="last_seen">最終接続: %s</string>
     <string name="save_profile_description">自己紹介保存</string>
@@ -451,9 +451,9 @@
     <string name="clan_full">クランが満員です。</string>
     <string name="clan_join_button_full">クラン満員</string>
     <string name="clan_join_request_sent">申請を送信しました</string>
-    <string name="clan_invite_list_full">This clan's invite list is full (max 100).</string>
+    <string name="clan_invite_list_full">このクランの招待リストが満員です（最大100件）。</string>
     <string name="clan_player_invite_list_full">このユーザーの保留中の招待はすでに上限に達しています。</string>
-    <string name="clan_request_list_full">This clan's join request list is full (max 100).</string>
+    <string name="clan_request_list_full">このクランの加入申請リストが満員（最大100件）です。</string>
     <string name="clan_donate_voidstones">ボイドストーン寄付</string>
     <string name="clan_donate_hint">100枚〜100,000枚</string>
     <string name="clan_donate_sent">寄付完了！</string>
@@ -478,7 +478,7 @@
     <string name="clan_search_hint">名前またはIDで検索する</string>
     <string name="clan_promote_to_owner">オーナーシップ移転</string>
     <string name="clan_transfer_ownership_title">オーナーシップの移転</string>
-    <string name="clan_transfer_ownership_message">You are about to promote \"%1$s\" (ID: %2$d) to Owner. You will be demoted to Co-Owner. This cannot be undone.\n\nType the player's ID to confirm:</string>
+    <string name="clan_transfer_ownership_message">オーナーシップを「%1$s」さん（ID %2$d）に移転しますか？あなたは共同オーナーになります。これは元に戻せません。\n\nユーザーIDを入力して確認してください:</string>
     <string name="clan_transfer_ownership_id_mismatch">無効なIDです。</string>
     <string name="clan_customize_name_color">クラン名カラー</string>
     <string name="clan_customize_tag_color">クランタグカラー</string>
@@ -513,8 +513,8 @@
     <!-- Leaderboard !-->
     <string name="leaderboard_type">リーダーボード種類</string>
     <string name="leaderboard_xp_description">経験値です。獲得してレベルアップします。経験値はドットやボイドストーンを集めて得られます。</string>
-    <string name="leaderboard_competitive_description">Ranked 1v1 ladder. Only players who have completed at least 12 competitive matches are listed.</string>
-    <string name="leaderboard_rating">Rating</string>
+    <string name="leaderboard_competitive_description">1対1のランキングマッチです。ランクバトルで12試合以上完了したプレイヤーのみは表示されます。</string>
+    <string name="leaderboard_rating">ランキング</string>
     <string name="leaderboard_period_daily">デイリー</string>
     <string name="leaderboard_period_weekly">ウィークリー</string>
     <string name="leaderboard_period_monthly">マンスリー</string>
@@ -588,7 +588,7 @@
     <string name="gamemode_adventure">アドベンチャー</string>
     <string name="gamemode_soccer">サッカー</string>
     <string name="gamemode_coming_soon">近日公開</string>
-    <string name="gamemode_competitive">Competitive</string>
+    <string name="gamemode_competitive">バトル</string>
     <string name="gamemode_multimerg">MultiMerg</string>
     <string name="description_classic">小さいプレイヤーを食べてマップで最大のブロブになろう！サイズを使ってマップを制しよう。だがより大きなブロブに気をつけてね！</string>
     <string name="description_teams">同じカラーのプレイヤーに入ろう！敵チームのプレイヤーブロブを食べて、チームがリーダーボードを制するようにしよう！チームメイトは同じチームのプレイヤーを食べられない。</string>
@@ -598,7 +598,7 @@
     <string name="description_adventure">ユニークな目的のアドベンチャーステージをクリアしよう！難易度はステージが進むにつれて上がり、ボーナスを獲得し、スキルを披露しよう！各ステージで難易度が上がる！</string>
     <string name="description_soccer">相手のゴールにシュートを決めよう。タイムアップ時に得点多いチームの勝ち！</string>
     <string name="description_coming_soon">このゲームモードは近日公開予定です。続報を待ちましょう！</string>
-    <string name="description_competitive">Ranked 1v1 survival! Earn rating by beating opponents of similar skill. A 3-minute match with a 2-minute overtime if neither player dies. Win to climb the global leaderboard, lose and drop down, but the rating swing depends on the gap between you and your opponent.</string>
+    <string name="description_competitive">1対1のランキング戦サバイバル！同じくらいのスキルの相手を倒して、ランキングに入ろう。2人のプレイヤーが生存した場合、3分間のマッチと2分間の延長時間が得られる。勝ってグローバルランキングを駆け上がり、負けたら下がってしまう。ランキングの変動は2人のプレイヤーのスキル差によって決まる。</string>
     <string name="description_multimerg">You spawn TWO blobs and switch control between them with the yin-yang button! Only the active blob responds to your joystick, split, and shoot. The other one keeps moving in its last direction. Your two blobs can eat each other if split, but the final piece is protected.</string>
 
     <!-- Map sizes !-->
@@ -761,7 +761,7 @@
     <string name="dialog_notice">注意</string>
     <string name="dialog_warning">警告</string>
     <string name="dialog_alert">警告</string>
-    <string name="dialog_dont_show_again">Don't show again</string>
+    <string name="dialog_dont_show_again">再表示しない</string>
     <string name="dialog_dismiss">取り消す</string>
     <string name="dialog_previous">前へ</string>
     <string name="dialog_next">次へ</string>
@@ -779,7 +779,7 @@
     <string name="block_player">ブロック</string>
     <string name="unblock_player">ブロック解除</string>
     <string name="block_confirm_title">プレイヤーをブロックしますか？</string>
-    <string name="block_confirm_message">Are you sure you want to block %s? You will both be unable to send each other mails or friend requests, and will be removed from each other's friends list.</string>
+    <string name="block_confirm_message">「%s」さんをブロックしてもよろしいですか？このプレイヤーからのメールまたはフレンド申請を受信できないようになり、フレンドから解除されます。</string>
     <string name="player_unblocked">プレイヤーをブロック解除しました</string>
     <string name="player_blocked">プレイヤーをブロックしました</string>
     <string name="you_blocked_user">プレイヤーをブロックしました</string>
@@ -795,12 +795,12 @@
     <string name="enter_ip">IP入力</string>
     <string name="join_ip_title">IPアドレスに参加</string>
     <string name="tap_to_reveal">タップして表示</string>
-    <string name="remote_lan_connections">To allow other clients to join remotely through public IP, you must port forward UDP %d or enable DMZ for your device on your router's settings. Please note that connections may still fail if your network is under Symmetric NAT/CGNAT. For more information and to check your current NAT type, visit %s.</string>
+    <string name="remote_lan_connections">他のクライアントがグローバルIP経由でリモート参加するには、このデバイスにUDP %dポートを転送するか、ルーター設定でDMZをオンにする必要があります。ネットワーク環境が対称型NAT／CGNATを使用している場合、接続に失敗する可能性があるためでご注意ください。詳細の確認や現在のNATタイプをチェックするには、%sにアクセスしてください。</string>
 
     <!-- Player List -->
     <string name="players">プレイヤー</string>
-    <string name="spectators">Spectators</string>
-    <string name="joined_room">Joined room %s</string>
+    <string name="spectators">観戦者数</string>
+    <string name="joined_room">ルーム「%s」に入りました</string>
     <string name="player_list_title">プレイヤーリスト</string>
     <string name="staff_list_title">STAFF LIST</string>
     <string name="player_list_count">プレイヤー数: %d・ボット数: %d・総数: %d</string>
@@ -947,7 +947,7 @@
     <string name="previous_entity">前のエンティティ</string>
     <string name="next_entity">次のエンティティ</string>
     <string name="level_abbreviated">Lv.%d</string>
-    <string name="left">Left</string> <!-- left as in remaining, not the left direction -->
+    <string name="left">残り</string> <!-- left as in remaining, not the left direction -->
     <string name="total">合計</string>
     <string name="unknown">不明</string>
     <string name="invalid_selection">無効な選択です！</string>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -149,7 +149,7 @@
     <string name="remove_friend_message">Tem certeza de que deseja remover \"%1$s\" (ID: %2$d) da sua lista de amigos?</string>
     <string name="cancel_request_title">Cancelar Solicitação</string>
     <string name="cancel_request_message">Tem certeza de que deseja excluir a solicitação de amizade pendente com \"%1$s\" (ID: %2$d)?</string>
-    <string name="friend_request_error_self">Can't send friend request to yourself</string>
+    <string name="friend_request_error_self">Não é possível adicionar a si mesmo(a).</string>
     <string name="friend_request_error_already_sent">Solicitação de amizade já enviada</string>
     <string name="friend_request_error_already_friends">Já são amigos</string>
     <string name="friend_request_error_list_full">A lista de amigos atingiu o limite</string>
@@ -157,34 +157,34 @@
     <!-- Competitive (ranked 1v1) -->
     <string name="competitive">Competitivo</string>
     <string name="competitive_menu">COMPETITIVO</string>
-    <string name="competitive_history">Competitive History</string>
-    <string name="rating_label">Rating</string>
+    <string name="competitive_history">Histórico de Competições</string>
+    <string name="rating_label">Classificação</string>
     <string name="unrated">Não Classificado(a)</string>
     <string name="find_opponent">PROCURAR ADVERSÁRIO</string>
     <string name="leave_matchmaking">SAIR DA FORMAÇÃO</string>
-    <string name="searching_ellipsis">Searching…</string>
-    <string name="x_searching_y_playing">%1$s searching · %2$s playing</string>
+    <string name="searching_ellipsis">Procurando…</string>
+    <string name="x_searching_y_playing">%1$s procurando · %2$s em andamento</string>
     <string name="x_searching">%d searching</string>
     <string name="x_playing">%d playing</string>
     <string name="global_position">Global #%s</string>
     <string name="global_label">Global #</string>
-    <string name="wins_draws_losses_winrate">Wins: %1$s · Draws: %2$s · Losses: %3$s · Win rate: %4$s%%</string>
-    <string name="stat_wins_label">Wins: </string>
-    <string name="stat_draws_label"> · Draws: </string>
-    <string name="stat_losses_label"> · Losses: </string>
-    <string name="stat_winrate_label"> · Win rate: </string>
+    <string name="wins_draws_losses_winrate">Vitórias: %1$s · Empates: %2$s · Perdas: %3$s · Taxa de vitórias: %4$s%%</string>
+    <string name="stat_wins_label">Vitórias: </string>
+    <string name="stat_draws_label"> · Empates: </string>
+    <string name="stat_losses_label"> · Perdas: </string>
+    <string name="stat_winrate_label"> · Taxa de vitórias: </string>
     <string name="match_starts_in">Partida começando em…</string>
     <string name="vs_label">VS</string>
-    <string name="ongoing_matches">Ongoing matches</string>
-    <string name="match_status_starting">STARTING</string>
-    <string name="match_status_in_progress">IN PROGRESS</string>
-    <string name="match_status_finished">FINISHED</string>
+    <string name="ongoing_matches">Partidas em andamento</string>
+    <string name="match_status_starting">COMEÇANDO</string>
+    <string name="match_status_in_progress">EM ANDAMENTO</string>
+    <string name="match_status_finished">TERMINOU</string>
     <string name="victory">VITÓRIA</string>
     <string name="defeat">DERROTA</string>
     <string name="draw">EMPATE</string>
-    <string name="play_again">Play Again</string>
-    <string name="play_x_more_matches_to_rated">Play %d more matches to be rated!</string>
-    <string name="play_one_more_match_to_rated">Play 1 more match to be rated!</string>
+    <string name="play_again">Jogar Novamente</string>
+    <string name="play_x_more_matches_to_rated">Jogue mais %d partidas para se classificar!</string>
+    <string name="play_one_more_match_to_rated">Jogue mais 1 partida para se classificar!</string>
     <string name="history_viewer_vs_opponent">%1$s vs %2$s</string>
     <string name="prizes">Prizes</string>
     <string name="prizes_dialog_intro">Before every season reset, top players will receive a Voidstone reward based on their performance!</string>
@@ -243,7 +243,7 @@
     <string name="ad_not_loaded">Anúncio ainda não carregado</string>
     <string name="ad_show_failed">Falha ao exibir o anúncio</string>
     <string name="ad_load_failed">Falha ao carregar o anúncio</string>
-    <string name="ad_rate_limited">You've watched too many ads recently. Please try again in %s.</string>
+    <string name="ad_rate_limited">Muitos anúncios foram exibidos em curto prazo. Tente novamente em %s.</string>
     <string name="time_hrs">hrs</string>
     <string name="time_min">min</string>
     <string name="time_sec">seg</string>
@@ -274,13 +274,13 @@
     <string name="not_logged_in">Não conectado(a)!</string>
     <string name="login">Fazer login</string>
     <string name="login_google">Entrar com Google</string>
-    <string name="login_apple">Sign in with Apple</string>
+    <string name="login_apple">Entrar com Apple</string>
     <string name="logout">Desconectar-se</string>
     <string name="logout_all_devices">Desconectar-se de Todos os Dispositivos</string>
     <string name="change_name">Alterar Nome</string>
     <string name="copy_id">Copiar ID</string>
-    <string name="share_id">Share ID</string>
-    <string name="share_id_message">Add me on Merg! My ID is %1$s</string>
+    <string name="share_id">Compartilhar ID</string>
+    <string name="share_id_message">Me adicione no Merg! Este é o meu ID: %1$s</string>
     <string name="created">Criou em: %s</string>
     <string name="last_seen">Visto(a) por último: %s</string>
     <string name="save_profile_description">Salvar Biografia</string>
@@ -451,9 +451,9 @@
     <string name="clan_full">Este clã está cheio.</string>
     <string name="clan_join_button_full">Clã Cheio</string>
     <string name="clan_join_request_sent">Solicitação Enviada</string>
-    <string name="clan_invite_list_full">This clan's invite list is full (max 100).</string>
+    <string name="clan_invite_list_full">A lista de convites desse clã está cheia (máx. 100).</string>
     <string name="clan_player_invite_list_full">O número de convites enviados para este(a) jogador(a) já atingiu o limite.</string>
-    <string name="clan_request_list_full">This clan's join request list is full (max 100).</string>
+    <string name="clan_request_list_full">A lista de solicitações de entrada desse clã está cheia (máx. 100).</string>
     <string name="clan_donate_voidstones">Doar Voidstones</string>
     <string name="clan_donate_hint">Valor (100 – 100.000)</string>
     <string name="clan_donate_sent">Doação concluída!</string>
@@ -478,7 +478,7 @@
     <string name="clan_search_hint">Procurar por ID ou nome</string>
     <string name="clan_promote_to_owner">Promover a Dono(a)</string>
     <string name="clan_transfer_ownership_title">Transferir Liderança</string>
-    <string name="clan_transfer_ownership_message">You are about to promote \"%1$s\" (ID: %2$d) to Owner. You will be demoted to Co-Owner. This cannot be undone.\n\nType the player's ID to confirm:</string>
+    <string name="clan_transfer_ownership_message">Tem certeza de que deseja transferir a liderança para \"%1$s\" (ID: %2$d)? Você se tornará vice-dono(a) do clã. Esta ação é irreversível.\n\nInsira o ID do(a) jogador(a) para confirmar:</string>
     <string name="clan_transfer_ownership_id_mismatch">O ID não corresponde.</string>
     <string name="clan_customize_name_color">Cor do Nome do Clã</string>
     <string name="clan_customize_tag_color">Cor da Tag do Clã</string>
@@ -513,8 +513,8 @@
     <!-- Leaderboard !-->
     <string name="leaderboard_type">Tipo de Placar</string>
     <string name="leaderboard_xp_description">XP: Necessário para subir de nível. Pode ser obtido realizando alguma ação significativa no jogo.</string>
-    <string name="leaderboard_competitive_description">Ranked 1v1 ladder. Only players who have completed at least 12 competitive matches are listed.</string>
-    <string name="leaderboard_rating">Rating</string>
+    <string name="leaderboard_competitive_description">Partida classificatória 1v1. Somente jogadores que concluírem pelo menos 12 partidas aparecerão na lista.</string>
+    <string name="leaderboard_rating">Classificação</string>
     <string name="leaderboard_period_daily">Diário</string>
     <string name="leaderboard_period_weekly">Semanal</string>
     <string name="leaderboard_period_monthly">Mensal</string>
@@ -588,7 +588,7 @@
     <string name="gamemode_adventure">Aventura</string>
     <string name="gamemode_soccer">Futebol</string>
     <string name="gamemode_coming_soon">Em Breve</string>
-    <string name="gamemode_competitive">Competitive</string>
+    <string name="gamemode_competitive">Competitivo</string>
     <string name="gamemode_multimerg">MultiMerg</string>
     <string name="description_classic">Absorva jogadores menores e torne-se o maior blob do universo! Use o seu tamanho para dominar o mapa, mas tome cuidado com os jogadores maiores perseguindo você!</string>
     <string name="description_teams">Una-se com outros jogadores da mesma cor! Enfrente adversários junto e faça a sua equipe dominar o placar. Os companheiros de equipe não poderão matar um ao outro.</string>
@@ -598,7 +598,7 @@
     <string name="description_adventure">Conclua fases desafiadoras com objetivos únicos! Obtenha progresso no decorrer de que a dificuldade aumenta, ganhe recompensas e veja até onde você consegue chegar. Cada fase traz consigo novos desafios!</string>
     <string name="description_soccer">Chute a bola até o gol do time adversário. O time com o maior número de gols assim que o tempo acabar será o ganhador!</string>
     <string name="description_coming_soon">Esse modo de jogo chegará em breve, fique antenado(a)!</string>
-    <string name="description_competitive">Ranked 1v1 survival! Earn rating by beating opponents of similar skill. A 3-minute match with a 2-minute overtime if neither player dies. Win to climb the global leaderboard, lose and drop down, but the rating swing depends on the gap between you and your opponent.</string>
+    <string name="description_competitive">Sobrevivência classificatória 1v1! Obtenha classificação derrotando adversários com habilidades semelhantes. Uma partida de 3 minutos com um acréscimo de 2 minutos começará se ambos os jogadores sobreviverem. Cada vitória fará subir no ranking global, enquanto cada derrota fará cair, mas a variação da classificação dependerá na diferença de habilidade entre você e o(a) adversário(a).</string>
     <string name="description_multimerg">You spawn TWO blobs and switch control between them with the yin-yang button! Only the active blob responds to your joystick, split, and shoot. The other one keeps moving in its last direction. Your two blobs can eat each other if split, but the final piece is protected.</string>
 
     <!-- Map sizes !-->
@@ -761,7 +761,7 @@
     <string name="dialog_notice">Nota</string>
     <string name="dialog_warning">Aviso</string>
     <string name="dialog_alert">Alerta</string>
-    <string name="dialog_dont_show_again">Don't show again</string>
+    <string name="dialog_dont_show_again">Não exibir novamente</string>
     <string name="dialog_dismiss">Esquecer</string>
     <string name="dialog_previous">Anterior</string>
     <string name="dialog_next">Próximo</string>
@@ -779,7 +779,7 @@
     <string name="block_player">Bloquear Jogador(a)</string>
     <string name="unblock_player">Desbloquear Jogador(a)</string>
     <string name="block_confirm_title">Bloquear Jogador(a)?</string>
-    <string name="block_confirm_message">Are you sure you want to block %s? You will both be unable to send each other mails or friend requests, and will be removed from each other's friends list.</string>
+    <string name="block_confirm_message">Tem certeza de que deseja bloquear este(a) jogador(a): %s? Você não receberá mais mensagens ou solicitação de amizade dele(a) e ele(a) será excluído(a) da sua lista de amigos.</string>
     <string name="player_unblocked">Jogador(a) desbloqueado(a)</string>
     <string name="player_blocked">Jogador(a) bloqueado(a)</string>
     <string name="you_blocked_user">Você bloqueou</string>
@@ -795,12 +795,12 @@
     <string name="enter_ip">Inserir IP</string>
     <string name="join_ip_title">Entrar no Endereço IP</string>
     <string name="tap_to_reveal">Toque para revelar</string>
-    <string name="remote_lan_connections">To allow other clients to join remotely through public IP, you must port forward UDP %d or enable DMZ for your device on your router's settings. Please note that connections may still fail if your network is under Symmetric NAT/CGNAT. For more information and to check your current NAT type, visit %s.</string>
+    <string name="remote_lan_connections">É necessário redirecionar a porta UDP %d ou, nas configurações do seu roteador, ativar o DMZ para permitir que outros clientes entrem usando seu IP público. As conexões poderão falhar mesmo se a sua rede estiver sob um NAT/CGNAT Simétrico. Para saber mais e verificar o tipo de NAT do seu provedor de Internet, visite %s.</string>
 
     <!-- Player List -->
     <string name="players">Jogadores</string>
-    <string name="spectators">Spectators</string>
-    <string name="joined_room">Joined room %s</string>
+    <string name="spectators">Espectadores</string>
+    <string name="joined_room">Entrou na sala %s</string>
     <string name="player_list_title">LISTA DE JOGADORES</string>
     <string name="staff_list_title">STAFF LIST</string>
     <string name="player_list_count">Jogadores: %d ⋅ Bots: %d ⋅ Total: %d</string>
@@ -947,7 +947,7 @@
     <string name="previous_entity">Entidade Anterior</string>
     <string name="next_entity">Próxima Entidade</string>
     <string name="level_abbreviated">Nv.%d</string>
-    <string name="left">Left</string> <!-- left as in remaining, not the left direction -->
+    <string name="left">Restante</string> <!-- left as in remaining, not the left direction -->
     <string name="total">Total</string>
     <string name="unknown">Desconhecido</string>
     <string name="invalid_selection">Seleção inválida!</string>


### PR DESCRIPTION
## Summary

PR #124's merge script had two bugs that caused 110 translator values to be overwritten with English:

1. **Wrong "previous English" baseline**: the script used `merg-1.0-alpha-translations:res/values/strings.xml` (840 keys, an old frozen version) instead of `main:commonMain/values/strings.xml` (864 keys). Every key present in main but absent from the older 840-key baseline was wrongly flagged as "new in English" — so the existing translation for those keys got replaced with the English value in every locale that had translated them.
2. **Regex missed trailing comments**: the `<string>` matcher required `</string>` to be at end of line. The one key with a trailing dev comment (`left` — `<!-- left as in remaining ... -->`) was silently skipped and the English value got copied into every locale.

## Damage

- Arabic: 4 lost
- Spanish: 34 lost
- Japanese: 36 lost
- Portuguese (Brazil): 33 lost
- Plus 3 more for `left` (es, ja, pt-rBR)

Total: 110 cells restored from `c1112d9` (last translator-merge commit before PR #124). Other locales had no translations for the affected keys, so no restoration needed.

## Verification

Audit: zero remaining translator-value losses across all 27 locales. Every cell now matches either:
- Its original c1112d9 translation, or
- The current English baseline (where the locale legitimately had no translation pre-merge).

## Skill fix

The `sync-translations` skill's `merge.py` will be updated in a separate codebase commit to (a) use `main` as the previous-English baseline and (b) fix the regex to allow trailing content on `<string>` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)