### PR TITLE
Merg 1.1.1: Update all language files

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-bn/strings.xml
+++ b/commonMain/values-bn/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-cs/strings.xml
+++ b/commonMain/values-cs/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-da/strings.xml
+++ b/commonMain/values-da/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-de/strings.xml
+++ b/commonMain/values-de/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-el/strings.xml
+++ b/commonMain/values-el/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Ups, ya Solicitaste Unirse a este Clan.</string>
     <string name="before">Antes</string>
     <string name="after">Después</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-fi/strings.xml
+++ b/commonMain/values-fi/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-fr/strings.xml
+++ b/commonMain/values-fr/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-hi/strings.xml
+++ b/commonMain/values-hi/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-id/strings.xml
+++ b/commonMain/values-id/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-it/strings.xml
+++ b/commonMain/values-it/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">既にクラン参加リクエストを送信しました</string>
     <string name="before">以前</string>
     <string name="after">現在</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-ko/strings.xml
+++ b/commonMain/values-ko/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-nl/strings.xml
+++ b/commonMain/values-nl/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-pl/strings.xml
+++ b/commonMain/values-pl/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Já solicitou para entrar no clã</string>
     <string name="before">Antes</string>
     <string name="after">Agora</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-pt-rPT/strings.xml
+++ b/commonMain/values-pt-rPT/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-ro/strings.xml
+++ b/commonMain/values-ro/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-ru/strings.xml
+++ b/commonMain/values-ru/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-sv/strings.xml
+++ b/commonMain/values-sv/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-th/strings.xml
+++ b/commonMain/values-th/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-tl/strings.xml
+++ b/commonMain/values-tl/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-tr/strings.xml
+++ b/commonMain/values-tr/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-vi/strings.xml
+++ b/commonMain/values-vi/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-zh-rCN/strings.xml
+++ b/commonMain/values-zh-rCN/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values-zh-rTW/strings.xml
+++ b/commonMain/values-zh-rTW/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>

--- a/commonMain/values/strings.xml
+++ b/commonMain/values/strings.xml
@@ -992,4 +992,6 @@
     <string name="clan_already_requested_other">Already requested to join this clan</string>
     <string name="before">Before</string>
     <string name="after">After</string>
+    <string name="clan_id">Clan ID:</string>
+    <string name="editing_message">Editing message</string>
 </resources>


### PR DESCRIPTION
## Summary

Restructured against the current English baseline (now 918 keys, up from 916).

- **2 new English keys** copied verbatim into every locale as placeholders. Translators please replace with localized text:
  - `clan_id` — \"Clan ID:\" label on the clan profile.
  - `editing_message` — \"Editing message\" indicator in the in-game chat input bar.
- **0 reset keys** — no existing English content changed, so every translated value is preserved verbatim.
- **0 removed keys.**
- File structure, key order, comments, blank lines now match the English baseline exactly.

Includes the prior \`values-fil\` → \`values-tl\` rename already merged on main (5d666a6 / 2a3534e). Client code (\`Language.kt\`) updated to use the new \`\"tl\"\` short-code + a legacy migration so users whose saved language is \"fil\" don't fall back to English on first launch.

## Translator-work safety

Ran the loss-audit from PR #124's follow-up: **4176 translator-translated cells on \`origin/main\` are preserved 1:1 in this PR**. Zero unexplained mutations.

## Test plan
- [ ] Translators: replace the 2 placeholder English values (\`clan_id\`, \`editing_message\`) in each \`commonMain/values-XX/strings.xml\` with the localized text.
- [ ] Sanity: \`wc -l\` shows every locale at the same line count as \`values/strings.xml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)