### PR TITLE
Merg 1.1.1.1: Update all language files

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -23,7 +23,7 @@
     <string name="language_arabic">العربية</string>
     <string name="language_bengali">বাংলা</string>
     <string name="language_chinese">中文</string>
-   <string name="language_chinese_traditional">繁體中文</string>
+    <string name="language_chinese_traditional">繁體中文</string>
     <string name="language_czech">Čeština</string>
     <string name="language_danish">Dansk</string>
     <string name="language_dutch">Nederlands</string>
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">اختر مربعا وشاهد إعلان فيديو قصيرا لتربح فويدستون!</string>
     <string name="free_voidstones_won">لقد حصلت على %d فويدستون!</string>
     <string name="free_voidstones_status">متبقي %1$d ⋅ يعاد كل %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">يختار</string>
     <string name="redeem_code">استرداد الرمز</string>
     <string name="invalid_code">رمز غير صالح</string>
@@ -212,7 +213,7 @@
     <string name="reward_profile_triple_gradient">تدرج ثلاثي للون الملف</string>
     <string name="reward_profile_description_color">لون وصف الملف</string>
     <string name="reward_name_font">خط الاسم</string>
-    <string name="reward_already_owned_compensation">مملوك مسبقاً. تم التحويل إلى فويدستون</string>    
+    <string name="reward_already_owned_compensation">مملوك مسبقاً. تم التحويل إلى فويدستون</string>
     <string name="purchase_id">معرف الشراء: %d</string>
     <string name="history">History</string>
     <string name="voidstone_history">تاريخ الفويدستون</string>

--- a/commonMain/values-bn/strings.xml
+++ b/commonMain/values-bn/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-cs/strings.xml
+++ b/commonMain/values-cs/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-da/strings.xml
+++ b/commonMain/values-da/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-de/strings.xml
+++ b/commonMain/values-de/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-el/strings.xml
+++ b/commonMain/values-el/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">¡Mira un Anuncio corto para ganar Voidstones gratis!</string>
     <string name="free_voidstones_won">¡Ganaste %d Voidstones!</string>
     <string name="free_voidstones_status">%1$d Restantes ⋅ Reinicio en %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Elegir</string>
     <string name="redeem_code">Canjear Código</string>
     <string name="invalid_code">Código Inválido</string>
@@ -264,7 +265,7 @@
      <string name="october">Octubre</string>
      <string name="november">Noviembre</string>
      <string name="december">Diciembre</string>
-     <string name="season_bag_title">Bolsa de monedas/string>
+     <string name="season_bag_title">Bolsa de monedas</string>
      <string name="season_bag_entry">Temporada %1$s — %2$s (%3$s)</string>
      <string name="season_bag_current">Actual</string>
      <string name="season_bag_last">Último</string>
@@ -994,4 +995,4 @@
     <string name="after">Después</string>
     <string name="clan_id">Clan ID:</string>
     <string name="editing_message">Editing message</string>
-    </resources>
+</resources>

--- a/commonMain/values-fi/strings.xml
+++ b/commonMain/values-fi/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-fr/strings.xml
+++ b/commonMain/values-fr/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-hi/strings.xml
+++ b/commonMain/values-hi/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-id/strings.xml
+++ b/commonMain/values-id/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-it/strings.xml
+++ b/commonMain/values-it/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">マスを選んで、広告を視聴してボイドストーンをケットしよう！</string>
     <string name="free_voidstones_won">ボイドストーンを%d枚獲得しました！</string>
     <string name="free_voidstones_status">残り%1$d件・%2$s後にリセット</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">選ぶ</string>
     <string name="redeem_code">コードを利用</string>
     <string name="invalid_code">無効なコードです</string>

--- a/commonMain/values-ko/strings.xml
+++ b/commonMain/values-ko/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-nl/strings.xml
+++ b/commonMain/values-nl/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-pl/strings.xml
+++ b/commonMain/values-pl/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Escolha um quadradinho e assista a um anúncio de curta duração para obter Voidstones!</string>
     <string name="free_voidstones_won">%d Voidstones foram adicionadas à conta!</string>
     <string name="free_voidstones_status">%1$d restante(s) ⋅ Atualiza em %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Escolher</string>
     <string name="redeem_code">Resgatar Código</string>
     <string name="invalid_code">Código Inválido</string>

--- a/commonMain/values-pt-rPT/strings.xml
+++ b/commonMain/values-pt-rPT/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-ro/strings.xml
+++ b/commonMain/values-ro/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-ru/strings.xml
+++ b/commonMain/values-ru/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-sv/strings.xml
+++ b/commonMain/values-sv/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-th/strings.xml
+++ b/commonMain/values-th/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-tl/strings.xml
+++ b/commonMain/values-tl/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Kuha</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-tr/strings.xml
+++ b/commonMain/values-tr/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-vi/strings.xml
+++ b/commonMain/values-vi/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-zh-rCN/strings.xml
+++ b/commonMain/values-zh-rCN/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values-zh-rTW/strings.xml
+++ b/commonMain/values-zh-rTW/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>

--- a/commonMain/values/strings.xml
+++ b/commonMain/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="free_voidstones_subtitle">Pick a square and watch a short video ad to earn voidstones!</string>
     <string name="free_voidstones_won">You got %d voidstones!</string>
     <string name="free_voidstones_status">%1$d left ⋅ Resets in %2$s</string>
+    <string name="free_voidstones_left">%d left</string>
     <string name="pick">Pick</string>
     <string name="redeem_code">Redeem Code</string>
     <string name="invalid_code">Invalid Code</string>


### PR DESCRIPTION
## Summary

Restructured against the current English baseline (now 919 keys, up from 918).

- **1 new English key**: \`free_voidstones_left\` (\"%d left\") — the Free Voidstones ad-button daily counter. Lands in every locale as an English placeholder; translators please replace. Single integer \`%d\` placeholder.
- **0 reset keys** — no existing English content drifted since the last drop, every translation is preserved verbatim.
- **0 removed keys.**
- File structure, key order, comments, blank lines match the English baseline exactly.

Also patches a translator typo from the PR #134 / #131 combined update on values-es: the \`season_bag_title\` closing tag was \`>Bolsa de monedas/string>\` (missing the leading \`<\`). Compose Resources rejects the XML; corrected here so the 1.1.1.1 client build doesn't fail on the next release sync.

## Translator-work safety

Ran the loss-audit from PR #124's follow-up: **4287 translator-translated cells on \`origin/main\` are preserved 1:1 in this PR**. Zero unexplained mutations.

## Test plan
- [ ] Translators: replace the 1 placeholder English value (\`free_voidstones_left\`) in each \`commonMain/values-XX/strings.xml\` with the localized text. Keep the \`%d\` placeholder.
- [ ] Sanity: every locale file is the same line count as \`values/strings.xml\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)