### PR TITLE
Merg 1.4.1: Update all language files

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">التعزيزات</string>
     <string name="booster_permanent_upgrades">ترقيات دائمة</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">مضاعف نقاط الخبرة بالإعلانات</string>
     <string name="booster_ad_xp_desc">شاهد فيديو للحصول على تعزيز مؤقت لنقاط الخبره!</string>
     <string name="booster_stacks_base_xp">تُضاف الى نقاط الخبرة الاساسيه</string>

--- a/commonMain/values-az/strings.xml
+++ b/commonMain/values-az/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-bn/strings.xml
+++ b/commonMain/values-bn/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-cs/strings.xml
+++ b/commonMain/values-cs/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boostery</string>
     <string name="booster_permanent_upgrades">Permanentní vylepšení</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Sleduj video za dočasný XP boost!</string>
     <string name="booster_stacks_base_xp">Sčítá se se základním XP</string>

--- a/commonMain/values-da/strings.xml
+++ b/commonMain/values-da/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-de/strings.xml
+++ b/commonMain/values-de/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-el/strings.xml
+++ b/commonMain/values-el/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Potenciadores</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-fi/strings.xml
+++ b/commonMain/values-fi/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-fr/strings.xml
+++ b/commonMain/values-fr/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-hi/strings.xml
+++ b/commonMain/values-hi/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-id/strings.xml
+++ b/commonMain/values-id/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Booster</string>
     <string name="booster_permanent_upgrades">Upgrade Permanen</string>
     <string name="booster_owned">dimiliki: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Pengganda XP Iklan</string>
     <string name="booster_ad_xp_desc">Tonton video untuk mendapatkan XP boost sementara!</string>
     <string name="booster_stacks_base_xp">Dapat Ditumpuk dengan XP Dasar</string>

--- a/commonMain/values-it/strings.xml
+++ b/commonMain/values-it/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">ブースター</string>
     <string name="booster_permanent_upgrades">永久アップグレード</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">広告経験値倍率</string>
     <string name="booster_ad_xp_desc">広告を視聴して一時的ななブーストをゲットしよう！</string>
     <string name="booster_stacks_base_xp">基本経験値を含むスタック</string>

--- a/commonMain/values-ko/strings.xml
+++ b/commonMain/values-ko/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-nl/strings.xml
+++ b/commonMain/values-nl/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-pl/strings.xml
+++ b/commonMain/values-pl/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Incrementos</string>
     <string name="booster_permanent_upgrades">Aprimoramentos Permanentes</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Multiplicador de XP por Anúncio</string>
     <string name="booster_ad_xp_desc">Assista a um vídeo de anúncio para obter um incremento de XP temporário!</string>
     <string name="booster_stacks_base_xp">Acúmulos com XP de Base</string>

--- a/commonMain/values-pt-rPT/strings.xml
+++ b/commonMain/values-pt-rPT/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-ro/strings.xml
+++ b/commonMain/values-ro/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-ru/strings.xml
+++ b/commonMain/values-ru/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-sk/strings.xml
+++ b/commonMain/values-sk/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-sv/strings.xml
+++ b/commonMain/values-sv/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-th/strings.xml
+++ b/commonMain/values-th/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-tl/strings.xml
+++ b/commonMain/values-tl/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-tr/strings.xml
+++ b/commonMain/values-tr/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Güçlendiriciler</string>
     <string name="booster_permanent_upgrades">Kalıcı Yükseltmeler</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Reklam XP Katlayıcı</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-uk/strings.xml
+++ b/commonMain/values-uk/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-vi/strings.xml
+++ b/commonMain/values-vi/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-zh-rCN/strings.xml
+++ b/commonMain/values-zh-rCN/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values-zh-rTW/strings.xml
+++ b/commonMain/values-zh-rTW/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>

--- a/commonMain/values/strings.xml
+++ b/commonMain/values/strings.xml
@@ -217,6 +217,8 @@
     <string name="boosters">Boosters</string>
     <string name="booster_permanent_upgrades">Permanent Upgrades</string>
     <string name="booster_owned">owned: %1$s</string>
+    <!-- Value shown for a booster the player has not bought any level of. -->
+    <string name="none">None</string>
     <string name="booster_ad_xp_title">Ad XP Multiplier</string>
     <string name="booster_ad_xp_desc">Watch a video for a temporary XP boost!</string>
     <string name="booster_stacks_base_xp">Stacks with Base XP</string>


### PR DESCRIPTION
Round-trip for **Merg 1.4.1**: translator work from `main` pulled into the codebase, every locale realigned to the current English baseline, and the result written back here.

### What changed since the 1.4 drop
- **1 new key** — `none` ("None"), the boosters card's *owned: None* hint for an upgrade nobody has bought yet. Shipped as an English placeholder in all 30 locales; it's the only line needing translation.
- **0 reset keys** — no English string was reworded, so nothing has to be re-translated.
- **0 removed keys.**

### Translator work merged in
Slovak from **jakub** (#248), plus Indonesian and Turkish updates. All of it is preserved: the audit reports **0 unexplained losses** across all 30 locales (values-sk 301 translated values kept, values-id 1009, values-tr 169, …).

No new locale folders this round.

Everything else in the diff is realignment — key order, comments and blank lines now match `values/strings.xml` line for line, which is what keeps future diffs readable.