### PR TITLE
Merg 1.4.5: Update all language files

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">أوروبا</string>
     <string name="server_americas_nc">أمريكا الشمالية والوسطى</string>
     <string name="server_south_america">أمريكا الجنوبية</string>
+    <string name="server_asia">Asia</string>
     <string name="join">دخول</string>
     <string name="create">إنشاء</string>
     <string name="create_chat_room">إنشاء غرفة دردشة</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-az/strings.xml
+++ b/commonMain/values-az/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Qatıl</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-bn/strings.xml
+++ b/commonMain/values-bn/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-cs/strings.xml
+++ b/commonMain/values-cs/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Evropa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Připojit se</string>
     <string name="create">Vytvořit</string>
     <string name="create_chat_room">VYTVOŘIT CHAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-da/strings.xml
+++ b/commonMain/values-da/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-de/strings.xml
+++ b/commonMain/values-de/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-el/strings.xml
+++ b/commonMain/values-el/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Américas (N/C)</string>
     <string name="server_south_america">Sudamérica</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Unirse</string>
     <string name="create">Crear</string>
     <string name="create_chat_room">CREAR CHAT DE SALA</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-fi/strings.xml
+++ b/commonMain/values-fi/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-fr/strings.xml
+++ b/commonMain/values-fr/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Rejoindre</string>
     <string name="create">Créer</string>
     <string name="create_chat_room">CRÉER UN SALON DE DISCUSSION</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-hi/strings.xml
+++ b/commonMain/values-hi/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">यूरोप</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">जुड़ें</string>
     <string name="create">बनाएं</string>
     <string name="create_chat_room">चैट रूम बनाएं</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-id/strings.xml
+++ b/commonMain/values-id/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Eropa</string>
     <string name="server_americas_nc">Amerika (Ut./Tgh.)</string>
     <string name="server_south_america">Amerika Selatan</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Gabung</string>
     <string name="create">Buat</string>
     <string name="create_chat_room">BUAT RUANG CHAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Tidak memunculkan Makanan atau Voidstone apa pun, untuk keperluan debugging.</string>
     <string name="desc_room_hidden">Ruang Anda tidak akan muncul dalam daftar ruang pribadi bagi orang lain, akses ke ruang tersebut hanya dapat dilakukan dengan memasukkan nama yang tepat.</string>
     <string name="scored">dicetak!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-it/strings.xml
+++ b/commonMain/values-it/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Entra</string>
     <string name="create">Crea</string>
     <string name="create_chat_room">CREA STANZA CHAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">ヨーロッパ</string>
     <string name="server_americas_nc">北米＋中米</string>
     <string name="server_south_america">南米</string>
+    <string name="server_asia">Asia</string>
     <string name="join">参加</string>
     <string name="create">作成</string>
     <string name="create_chat_room">チャットルームの作成</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-ko/strings.xml
+++ b/commonMain/values-ko/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-nl/strings.xml
+++ b/commonMain/values-nl/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Deelnemen</string>
     <string name="create">Aanmaken</string>
     <string name="create_chat_room">CHATKAMER AANMAKEN</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-pl/strings.xml
+++ b/commonMain/values-pl/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Dołącz</string>
     <string name="create">Utwórz</string>
     <string name="create_chat_room">UTWÓRZ CZAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Américas (Nrt./Cnt.)</string>
     <string name="server_south_america">América do Sul</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Entrar</string>
     <string name="create">Criar</string>
     <string name="create_chat_room">CRIAR SALA DE CHAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-pt-rPT/strings.xml
+++ b/commonMain/values-pt-rPT/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Entrar</string>
     <string name="create">Criar</string>
     <string name="create_chat_room">CHAT PERSONALIZADO</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-ro/strings.xml
+++ b/commonMain/values-ro/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-ru/strings.xml
+++ b/commonMain/values-ru/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Европа</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Войти</string>
     <string name="create">Создать</string>
     <string name="create_chat_room">СОЗДАТЬ ЧАТ-КОМНАТУ</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-sk/strings.xml
+++ b/commonMain/values-sk/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Európa</string>
     <string name="server_americas_nc">Amerika (S/St)</string>
     <string name="server_south_america">Južná Amerika</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Pripojiť sa</string>
     <string name="create">Vytvoriť</string>
     <string name="create_chat_room">VYTVORIŤ CHAT MIESTNOSŤ</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-sv/strings.xml
+++ b/commonMain/values-sv/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-th/strings.xml
+++ b/commonMain/values-th/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">ยุโรป</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">เข้าร่วม</string>
     <string name="create">สร้าง</string>
     <string name="create_chat_room">สร้างห้องแชท</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-tl/strings.xml
+++ b/commonMain/values-tl/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europa</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Sumali</string>
     <string name="create">Gumawa</string>
     <string name="create_chat_room">GUMAWA NG CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-tr/strings.xml
+++ b/commonMain/values-tr/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Avrupa</string>
     <string name="server_americas_nc">Kuzey/Orta Amerika</string>
     <string name="server_south_america">Güney Amerika</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Katıl</string>
     <string name="create">Oluştur</string>
     <string name="create_chat_room">ÖZEL ODA OLUŞTUR</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-uk/strings.xml
+++ b/commonMain/values-uk/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Європа</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Приєднатися</string>
     <string name="create">Створити</string>
     <string name="create_chat_room">СТВОРИТИ ЧАТ КІМНАТУ</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-vi/strings.xml
+++ b/commonMain/values-vi/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Châu Âu</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Tham gia</string>
     <string name="create">Tạo</string>
     <string name="create_chat_room">TẠO PHÒNG CHAT</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-zh-rCN/strings.xml
+++ b/commonMain/values-zh-rCN/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values-zh-rTW/strings.xml
+++ b/commonMain/values-zh-rTW/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>

--- a/commonMain/values/strings.xml
+++ b/commonMain/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="server_europe">Europe</string>
     <string name="server_americas_nc">Americas (N/C)</string>
     <string name="server_south_america">South America</string>
+    <string name="server_asia">Asia</string>
     <string name="join">Join</string>
     <string name="create">Create</string>
     <string name="create_chat_room">CREATE CHAT ROOM</string>
@@ -1190,4 +1191,8 @@
     <string name="desc_empty">Does not spawn any Food or Voidstones, for debugging purposes.</string>
     <string name="desc_room_hidden">Your room will not appear to people in the private rooms list, it can only be joined by specifying its exact name.</string>
     <string name="scored">scored!</string>
+    <!-- Soft hint shown under the raw error in the Disconnected dialog when the drop looks like a lost network connection (not a deliberate server disconnect). Worded as "usually" on purpose - a socket error can't be proven client-vs-server. -->
+    <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
+    <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
+    <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
 </resources>


### PR DESCRIPTION
Translation drop for **Merg 1.4.5**.

## What changed

| | count | action needed |
|---|---|---|
| **New keys** | **4** | Need translation — currently English placeholders |
| Reset keys | 0 | — |
| Removed keys | 0 | — |

### The 4 new keys

- `server_asia` — the new Asia (Singapore) server's region name in the multiplayer server list
- `disconnect_reason_network`, `reconnect_attempt_succeeded`, `reconnect_attempt_failed` — shown when an online game drops and the client reconnects

## Translator safety

**0 unexplained losses** across all 30 locales. Nothing was reset — no English strings changed this cycle, so no retranslation is needed anywhere.

Special thanks this cycle: **Mukan's Turkish pass nearly doubles Turkish coverage** (193 → 380 translated strings). All incoming work (`values-tr`, `values-id`, `values-zh-rTW` and others) is included.