### PR TITLE
Merg 1.4.6: Update all language files

### DIFF
--- a/commonMain/values-ar/strings.xml
+++ b/commonMain/values-ar/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-az/strings.xml
+++ b/commonMain/values-az/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-bn/strings.xml
+++ b/commonMain/values-bn/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-cs/strings.xml
+++ b/commonMain/values-cs/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-da/strings.xml
+++ b/commonMain/values-da/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-de/strings.xml
+++ b/commonMain/values-de/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-el/strings.xml
+++ b/commonMain/values-el/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-es/strings.xml
+++ b/commonMain/values-es/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-fi/strings.xml
+++ b/commonMain/values-fi/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-fr/strings.xml
+++ b/commonMain/values-fr/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-hi/strings.xml
+++ b/commonMain/values-hi/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-id/strings.xml
+++ b/commonMain/values-id/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-it/strings.xml
+++ b/commonMain/values-it/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-ja/strings.xml
+++ b/commonMain/values-ja/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-ko/strings.xml
+++ b/commonMain/values-ko/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-nl/strings.xml
+++ b/commonMain/values-nl/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-pl/strings.xml
+++ b/commonMain/values-pl/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-pt-rBR/strings.xml
+++ b/commonMain/values-pt-rBR/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-pt-rPT/strings.xml
+++ b/commonMain/values-pt-rPT/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-ro/strings.xml
+++ b/commonMain/values-ro/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-ru/strings.xml
+++ b/commonMain/values-ru/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-sk/strings.xml
+++ b/commonMain/values-sk/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-sv/strings.xml
+++ b/commonMain/values-sv/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-th/strings.xml
+++ b/commonMain/values-th/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-tl/strings.xml
+++ b/commonMain/values-tl/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-tr/strings.xml
+++ b/commonMain/values-tr/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-uk/strings.xml
+++ b/commonMain/values-uk/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-vi/strings.xml
+++ b/commonMain/values-vi/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-zh-rCN/strings.xml
+++ b/commonMain/values-zh-rCN/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values-zh-rTW/strings.xml
+++ b/commonMain/values-zh-rTW/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>

--- a/commonMain/values/strings.xml
+++ b/commonMain/values/strings.xml
@@ -1195,4 +1195,12 @@
     <string name="disconnect_reason_network">This is usually a problem with your internet connection (Wi-Fi, mobile data, or VPN), not the server.</string>
     <string name="reconnect_attempt_succeeded">Reconnection attempt #%1$d succeeded</string>
     <string name="reconnect_attempt_failed">Reconnection attempt #%1$d failed: %2$s</string>
+    <string name="save_preferences">Save preferences</string>
+    <string name="load_preferences">Load preferences</string>
+    <string name="preferences_saved">Preferences saved to %1$s</string>
+    <string name="preferences_loaded">Preferences loaded!</string>
+    <string name="preferences_transfer_failed">Preferences transfer failed: %1$s</string>
+    <string name="invalid_file">Invalid file</string>
+    <string name="unlocked">Unlocked:</string>
+    <string name="unlocked_competitive">Unlocked Competitive</string>
 </resources>


### PR DESCRIPTION
Adds the eight strings introduced this cycle to every language file, as English placeholders for translators to pick up:

  save_preferences, load_preferences, preferences_saved,
  preferences_loaded, preferences_transfer_failed, invalid_file
  (Options -> save/load a preferences profile)

  unlocked, unlocked_competitive
  (level-up notification: the skin you just unlocked, and crossing the
  server's competitive level gate)

Nothing else changed: no key was reordered, retranslated or removed, and the French and Spanish work merged since 1.4.5 (#253, #259) is carried through untouched.